### PR TITLE
Add --strict-field-splitting to keep empty field unremoved.

### DIFF
--- a/pawk.py
+++ b/pawk.py
@@ -26,7 +26,7 @@ RESULT_VAR_NAME = "__result"
 
 if sys.version_info[0] > 2:
     from itertools import zip_longest
-    
+
     try:
         exec_ = __builtins__['exec']
     except TypeError:
@@ -34,7 +34,7 @@ if sys.version_info[0] > 2:
     STRING_ESCAPE = 'unicode_escape'
 else:
     from itertools import izip_longest as zip_longest
-    
+
     def exec_(_code_, _globs_=None, _locs_=None):
         if _globs_ is None:
             frame = sys._getframe(1)
@@ -132,7 +132,10 @@ class Action(object):
 class Context(dict):
     def apply(self, numz, line, headers=None):
         l = line.rstrip()
-        f = [w for w in l.split(self.delim) if w]
+        if self.strict_field_splitting:
+            f = [w for w in l.split(self.delim)]
+        else:
+            f = [w for w in l.split(self.delim) if w]
         self.update(line=line, l=l, n=numz + 1, f=f, nf=len(f))
         if headers:
             self.update(zip_longest(headers, f))
@@ -150,6 +153,7 @@ class Context(dict):
         self.delim = codecs.decode(options.delim, STRING_ESCAPE) if options.delim else None
         self.odelim = codecs.decode(options.delim_out, STRING_ESCAPE)
         self.line_separator = codecs.decode(options.line_separator, STRING_ESCAPE)
+        self.strict_field_splitting = options.strict_field_splitting
 
         for m in modules:
             try:
@@ -210,6 +214,7 @@ def parse_commandline(argv):
     parser.add_option('-B', '--begin', help='begin statement', metavar='<statement>')
     parser.add_option('-E', '--end', help='end statement', metavar='<statement>')
     parser.add_option('-s', '--statement', action='store_true', help='DEPRECATED. retained for backward compatibility')
+    parser.add_option('-S', '--strict-field-splitting', action='store_true', help='do not remove empty field')
     parser.add_option('-H', '--header', action='store_true', help='use first row as field variable names in subsequent rows')
     parser.add_option('--strict', action='store_true', help='abort on exceptions')
     return parser.parse_args(argv[1:])

--- a/pawk.py
+++ b/pawk.py
@@ -132,7 +132,7 @@ class Action(object):
 class Context(dict):
     def apply(self, numz, line, headers=None):
         l = line.rstrip()
-        f = [w for w in l.split(self.delim)]
+        f = l.split(self.delim)
         self.update(line=line, l=l, n=numz + 1, f=f, nf=len(f))
         if headers:
             self.update(zip_longest(headers, f))
@@ -150,7 +150,6 @@ class Context(dict):
         self.delim = codecs.decode(options.delim, STRING_ESCAPE) if options.delim else None
         self.odelim = codecs.decode(options.delim_out, STRING_ESCAPE)
         self.line_separator = codecs.decode(options.line_separator, STRING_ESCAPE)
-        self.strict_field_splitting = options.strict_field_splitting
 
         for m in modules:
             try:
@@ -211,7 +210,6 @@ def parse_commandline(argv):
     parser.add_option('-B', '--begin', help='begin statement', metavar='<statement>')
     parser.add_option('-E', '--end', help='end statement', metavar='<statement>')
     parser.add_option('-s', '--statement', action='store_true', help='DEPRECATED. retained for backward compatibility')
-    parser.add_option('-S', '--strict-field-splitting', action='store_true', help='do not remove empty field')
     parser.add_option('-H', '--header', action='store_true', help='use first row as field variable names in subsequent rows')
     parser.add_option('--strict', action='store_true', help='abort on exceptions')
     return parser.parse_args(argv[1:])

--- a/pawk.py
+++ b/pawk.py
@@ -26,7 +26,7 @@ RESULT_VAR_NAME = "__result"
 
 if sys.version_info[0] > 2:
     from itertools import zip_longest
-
+    
     try:
         exec_ = __builtins__['exec']
     except TypeError:
@@ -34,7 +34,7 @@ if sys.version_info[0] > 2:
     STRING_ESCAPE = 'unicode_escape'
 else:
     from itertools import izip_longest as zip_longest
-
+    
     def exec_(_code_, _globs_=None, _locs_=None):
         if _globs_ is None:
             frame = sys._getframe(1)
@@ -132,10 +132,7 @@ class Action(object):
 class Context(dict):
     def apply(self, numz, line, headers=None):
         l = line.rstrip()
-        if self.strict_field_splitting:
-            f = [w for w in l.split(self.delim)]
-        else:
-            f = [w for w in l.split(self.delim) if w]
+        f = [w for w in l.split(self.delim)]
         self.update(line=line, l=l, n=numz + 1, f=f, nf=len(f))
         if headers:
             self.update(zip_longest(headers, f))

--- a/pawk_test.py
+++ b/pawk_test.py
@@ -21,6 +21,11 @@ drwxr-x---  6 alec  staff   204 Feb  9 21:09 pawk.egg-info/
 -rw-r-----  1 alec  staff   468 Feb 10 04:42 setup.py
 '''
 
+TEST_INPUT_CSV_WITH_EMPTY_FIELD = r'''
+model,color,price
+A01,,100
+B03,blue,200
+'''
 
 def run_integration_test(input, args):
     input = StringIO(input.strip())
@@ -73,6 +78,13 @@ def test_integration_truth():
 def test_integration_multiple_actions():
     out = run_integration_test(TEST_INPUT_LS, ['/setup/', '/README/'])
     assert [r.split()[-1] for r in out.splitlines()] == ['README.md', 'setup.py']
+
+
+def test_integration_csv_empty_fields():
+    out = run_integration_test(TEST_INPUT_CSV_WITH_EMPTY_FIELD, ['-F,', 'f[2]'])
+    assert out.splitlines() == ['price', '100', '200']
+    out = run_integration_test(TEST_INPUT_CSV_WITH_EMPTY_FIELD, ['-F,', 'f[1]'])
+    assert out.splitlines() == ['color', '', 'blue']
 
 
 def benchmark_fields():


### PR DESCRIPTION
Thank you for the useful tool, pawk.

When I tried to apply pawk to a spreadsheet-like file, I noticed that pawk does not allow empty fields.

E.g, for the following file including an empty field (at line 3):

```
$ cat tbl.csv
model,color,price
A01,blue,100
B03,,200
```

it is difficult to extract values of a column:

```
$ cat tbl.csv | pawk -F, 'f[2]'
price
100
```

So as a (possible) solution, I made an option (--strict-field-splitting or -S for short) to keep empty fields.

```
$ cat tbl.csv | python3 ~/playground/pawk/pawk.py -F, -S 'f[2]'
price
100
200
```

I'm not so fluent in English, so the name of the option (--strict-field-splitting) is perhaps not so good one, sorry.
